### PR TITLE
Bugfix for is_weighted() in models.py

### DIFF
--- a/tsplib95/models.py
+++ b/tsplib95/models.py
@@ -130,7 +130,7 @@ class Problem(File):
 
         :rtype: bool
         """
-        return bool(self.edge_weight_format)
+        return bool(self.edge_weight_format or self.edge_weight_type)
 
     def is_special(self):
         """Return True if the problem requires a special distance function.

--- a/tsplib95/models.py
+++ b/tsplib95/models.py
@@ -130,7 +130,7 @@ class Problem(File):
 
         :rtype: bool
         """
-        return bool(self.edge_weight_format or self.edge_weight_type)
+        return bool(self.edge_weight_format) or bool(self.edge_weight_type)
 
     def is_special(self):
         """Return True if the problem requires a special distance function.


### PR DESCRIPTION
The function `is_weighted()` in `models.py` returns `False` whenever the key EDGE_WEIGHT_FORMAT is not present in a tsplib file. However, this is frequently the case for instances that are defined through node coordinates and and EDGE_WEIGHT_TYPE, an example would be `ulysses16.tsp` as used in the documentation. For instances of this type, `_create_distance_function()` assumes the graph is unweighted and install a unit weight function as `wfunc`, thus the node coordinates are not respected. 

The _Usage_ section in the documentation suggest that this is not the intended behavior - for the example file `ulysses16.tsp` the call `problem.wfunc(1,11)` returns 26 in the documentation, for the current implementation it returns 1 instead. The proposed pull request solves this problem by also checking whether EDGE_WEIGHT_TYPE is present in the `is_weighted()` `function.`
