### PR TITLE
bugfix: models.is_complete() and models.is_depictable() throw exception

### DIFF
--- a/tsplib95/models.py
+++ b/tsplib95/models.py
@@ -144,7 +144,7 @@ class Problem(File):
 
         :rtype: bool
         """
-        return (self.edge_data_format is None)
+        return not bool(self.edge_data_format)
 
     def is_symmetric(self):
         """Return True if the problem is not asymmetrical.
@@ -161,13 +161,13 @@ class Problem(File):
 
         :rtype: bool
         """
-        if (self.display_data is not None):
+        if bool(self.display_data):
             return True
 
         if self.display_data_type == 'NO_DISPLAY':
             return False
 
-        return (self.node_coords is not None)
+        return bool(self.node_coords)
 
     def trace_tours(self, solution):
         """Calculate the total weights of the tours in the given solution.
@@ -250,7 +250,7 @@ class Problem(File):
             try:
                 return self.display_data[i]
             except TypeError:
-                return self.node_coord[i]
+                return self.node_coords[i]
         else:
             return None
 

--- a/tsplib95/models.py
+++ b/tsplib95/models.py
@@ -144,7 +144,7 @@ class Problem(File):
 
         :rtype: bool
         """
-        return 'EDGE_DATA_FORMAT' not in self
+        return (self.edge_data_format is None)
 
     def is_symmetric(self):
         """Return True if the problem is not asymmetrical.
@@ -161,13 +161,13 @@ class Problem(File):
 
         :rtype: bool
         """
-        if 'DISPLAY_DATA_SECTION' in self:
+        if (self.display_data is not None):
             return True
 
         if self.display_data_type == 'NO_DISPLAY':
             return False
 
-        return 'NODE_COORD_SECTION' in self
+        return (self.node_coords is not None)
 
     def trace_tours(self, solution):
         """Calculate the total weights of the tours in the given solution.


### PR DESCRIPTION
Both methods models.is_complete() and models.is_depictable()  throw an exception claiming the class Problem is not an iterable. The reason seems to be the use of the `in` operator, as the appropriate „magic method“ is not implemented in the class and the standard operator expects an iterable. Basically, the methods test if some attributes are set, so I just implemented that as testing the attributes for being „None / not None“.

I hope I got the parameter names correct, so please review carefully. Also, I am not sure whether the same kind of problem might exist elsewhere. By the way, thanks for the great library, it really spared me a lot of work that last week.