### PR TITLE
Bugfix: Alternate depots should be separated with newlines

### DIFF
--- a/tsplib95/fields.py
+++ b/tsplib95/fields.py
@@ -284,7 +284,7 @@ class DepotsField(TransformerField):
     @classmethod
     def build_transformer(cls):
         depot = T.FuncT(func=int)
-        return T.ListT(value=depot, terminal='-1')
+        return T.ListT(value=depot, terminal='-1', sep='\n')
 
 
 class DemandsField(TransformerField):

--- a/tsplib95/fields.py
+++ b/tsplib95/fields.py
@@ -284,7 +284,7 @@ class DepotsField(TransformerField):
     @classmethod
     def build_transformer(cls):
         depot = T.FuncT(func=int)
-        return T.ListT(value=depot, terminal='-1', sep='\n')
+        return T.ListT(value=depot, sep='\n', terminal='-1', terminal_required=False)
 
 
 class DemandsField(TransformerField):


### PR DESCRIPTION
`DEPOT_SECTION` should be a list of nodes separated by newlines and terminated with -1.