### PR TITLE
modify regex in StandardProblem.parse so we can load .tsp files we wrote

### DIFF
--- a/tsplib95/models.py
+++ b/tsplib95/models.py
@@ -98,7 +98,7 @@ class Problem(metaclass=FileMeta):
         """
         # prepare the regex for all known keys
         keywords = '|'.join(cls.fields_by_keyword)
-        sep = r'''\s*:\s*|\s*\n'''
+        sep = r'''\s*:\s*|\s*\n|\Z'''
         pattern = f'({keywords}|EOF)(?:{sep})'
 
         # split the whole text by known keys


### PR DESCRIPTION
StandardProblem.write places EOF at the end of the file. The TSPLIB standard specifies that EOF is a keyword and so is expected to be followed by a ":". StandardProblem.parse respected this aspect of the standard and so refused to match EOF unless it was followed by ":" or whitespace. We add that the file end ("\Z" in regex terms) is also acceptable so that the output of StandardProblem.write is acceptable input to StandardProblem.parse