### PR TITLE
Fix for loading tours

### DIFF
--- a/tsplib95/fields.py
+++ b/tsplib95/fields.py
@@ -369,7 +369,7 @@ class ToursField(Field):
                 tour_string = ' '.join(str(i) for i in tour)
                 tour_strings.append(f'{tour_string} -1')
 
-        if tour_strings:
+        if len(tour_strings) > 1:
             tour_strings += ['-1']
 
         return '\n'.join(tour_strings)

--- a/tsplib95/models.py
+++ b/tsplib95/models.py
@@ -103,6 +103,7 @@ class Problem(metaclass=FileMeta):
 
         # split the whole text by known keys
         regex = re.compile(pattern, re.M)
+        text += '\n' # ensure EOF is matched
         __, *results = regex.split(text)
 
         # pair keys and values

--- a/tsplib95/models.py
+++ b/tsplib95/models.py
@@ -99,11 +99,10 @@ class Problem(metaclass=FileMeta):
         # prepare the regex for all known keys
         keywords = '|'.join(cls.fields_by_keyword)
         sep = r'''\s*:\s*|\s*\n'''
-        pattern = f'({keywords}|EOF)(?:{sep})'
+        pattern = f'({keywords}|EOF)(?:{sep})|(?:EOF$)'
 
         # split the whole text by known keys
         regex = re.compile(pattern, re.M)
-        text += '\n' # ensure EOF is matched
         __, *results = regex.split(text)
 
         # pair keys and values
@@ -113,7 +112,7 @@ class Problem(metaclass=FileMeta):
         # parse into a dictionary
         data = {}
         for keyword, value in zip(field_keywords, field_values):
-            if keyword != 'EOF':
+            if keyword != 'EOF' and keyword is not None:
                 field = cls.fields_by_keyword[keyword]
                 name = cls.names_by_keyword[keyword]
                 data[name] = field.parse(value.strip())


### PR DESCRIPTION
Currently the following code will throw an error
```
import tsplib95
a = tsplib95.load("berlin52.opt.tour")
# do some stuff (or nothing)
a.save("x.tour")
tsplib95.load("x.tour") # this fails
```
This is because tsplib95 will miss the EOF in its regex if the user does not follow it by a blank space. This does not just affect tour loading but if you put extra info in a comment field which comes last then the EOF would be loaded in with the comment which is weird. I have fixed this by adding a new non-capturing group to the regex which will catch the EOF if it is at the very end. This match does have the consequence that the last keyword may then be None and so I have also addressed that. 

Also, a small nit is that in the original TSP_LIB files, they do not add an extra -1 when there is just one tour.