### PR TITLE
Save single tours in same form as TSP_LIB

### DIFF
--- a/tsplib95/fields.py
+++ b/tsplib95/fields.py
@@ -369,7 +369,7 @@ class ToursField(Field):
                 tour_string = ' '.join(str(i) for i in tour)
                 tour_strings.append(f'{tour_string} -1')
 
-        if tour_strings:
+        if len(tour_strings) > 1:
             tour_strings += ['-1']
 
         return '\n'.join(tour_strings)


### PR DESCRIPTION
This is a small nit but in the optimal tours from ALL_tsp they do not add the extra -1 if there is just one tour in the file. This will bring TSPLIB95s tour saving style in line with that of the original project.